### PR TITLE
Fixed torch 2.x bug in torch.istft()

### DIFF
--- a/speech_enhance/audio_zen/acoustics/feature.py
+++ b/speech_enhance/audio_zen/acoustics/feature.py
@@ -51,7 +51,9 @@ def istft(features, n_fft, hop_length, win_length, length=None, use_mag_phase=Fa
         # (mag, phase) or [mag, phase]
         assert isinstance(features, tuple) or isinstance(features, list)
         mag, phase = features
-        features = torch.stack([mag * torch.cos(phase), mag * torch.sin(phase)], dim=-1)
+        features = torch.complex(mag * torch.cos(phase), mag * torch.sin(phase))
+    else:
+        features = torch.complex(features[:, :, :, 0], features[:, :, :, 1])
 
     return torch.istft(
         features,


### PR DESCRIPTION
# Description:

When I wanted to run the repository for the first time I encountered this problem. 

```bash
File "/home/nahue/dev-personal/FullSubNet-plus/speech_enhance/audio_zen/acoustics/feature.py", line 58, in istft
    return torch.istft(
RuntimeError: istft requires a complex-valued input tensor matching the output from stft with return_complex=True.
```

It seems to be a bug or a major change in the way `torch.istft` works when moving from `torch` to version `2.x`. Now, `torch.istft` only accepts complex input, so I was able to fix the problem and use the code with this modification.

### Tests made on:
**Processor**: Intel® Core™ i5-10210U CPU @ 1.60GHz × 8
**OS**: Linux Ubuntu 22.04.4 LTS (64 bits)
**Torch version**: 2.2.2

